### PR TITLE
Add release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
   # Needed Environment Variables
   #    - PGP_PASSPHRASE = password for PGP private key
   #    - PGP_SECRET_ARMORED = PGP private key in ascii armored format.
+  #    - PGP_SIGNING_KEY_iD = The ID of the key to use for signing. This is configured in build.sbt in order
+  #                           not rely on the key being the default key, which is usually not the case when
+  #                           doing non-CI builds.
   #    - SONATYPE_TOKEN = JSON encoding of sonotype token user and password.
   publish-release:
     runs-on: "codebuild-ion-spark-data-source-${{ github.run_id }}-${{ github.run_attempt }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: "Publish Release Artifacts"
+on:
+  release:
+    types: [published]
+permissions:
+  contents: read
+jobs:
+  publish-release:
+    runs-on: "codebuild-ion-spark-data-source-${{ github.run_id }}-${{ github.run_attempt }}"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v3.6.0
+        with:
+          submodule: recursive
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          cache: sbt
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
+      - name: Publish
+        run: sbt ci-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
 permissions:
   contents: read
 jobs:
+  # Needed Environment Variables
+  #    - PGP_PASSPHRASE = password for PGP private key
+  #    - PGP_SECRET_ARMORED = PGP private key in ascii armored format.
+  #    - SONATYPE_TOKEN = JSON encoding of sonotype token user and password.
   publish-release:
     runs-on: "codebuild-ion-spark-data-source-${{ github.run_id }}-${{ github.run_attempt }}"
     steps:
@@ -19,5 +23,17 @@ jobs:
           cache: sbt
       - name: Setup sbt launcher
         uses: sbt/setup-sbt@v1
+        # Some of the secrets we have are not in the format that sbt-ci-release wants them in.
+        # So this step re-formats those values and sets up the environment for the Publish step.
+      - name: Setup Environment
+        run: |
+          TOKEN_USER="$(echo "$SONATYPE_TOKEN" | jq -r '. | keys[0]')"
+          TOKEN_SECRET="$(echo "$SONATYPE_TOKEN" | jq -r ". | .$TOKEN_USER")"
+          PGPKEY_BASE64="$(echo "$PGP_SECRET_ARMORED" | base64)"
+          {
+            echo "SONATYPE_USERNAME=\"$TOKEN_USER\"";
+            echo "SONATYPE_PASSWORD=\"$TOKEN_SECRET\"";
+            echo "PGP_SECRET=\"$PGPKEY_BASE64\"";
+          } >> "$GITHUB_ENV"
       - name: Publish
         run: sbt ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ addCommandAlias("releaseLocal", releaseTasks("publishLocal"))
 
 publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true)
 publishConfiguration := publishConfiguration.value.withOverwrite(true)
+pgpSigningKey := sys.env.get("PGP_SIGNING_KEY_ID")
 
 def releaseTasks(publishTask: String) = {
   val tasks = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ organization := "com.amazon.ion"
 organizationHomepage := Some(url("https://amazon-ion.github.io/ion-docs/"))
 name := s"ion-spark-data-source-$sparkMajorVersion"
 homepage := Some(url("https://github.com/amazon-ion/ion-spark-data-source"))
+licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 developers := List(
   Developer(
     "ion-team",
@@ -64,6 +65,13 @@ addCommandAlias("releaseLocal", releaseTasks("publishLocal"))
 publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true)
 publishConfiguration := publishConfiguration.value.withOverwrite(true)
 pgpSigningKey := sys.env.get("PGP_SIGNING_KEY_ID")
+
+// NOTE: CI release escape hatch: If a release needs to be manually pushed to maven central,
+// specify the options below. Ensure the version is correct, and run `sbt ci-release` locally
+// with the same environment variables needed for the CI build. This will circumvent any 'SNAPSHOT'
+// detection, and issues with the sbt-ci-release plugin not pushing releases outside of a CI env.
+// isSnapshot := false
+// version := "1.0.0"
 
 def releaseTasks(publishTask: String) = {
   val tasks = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,18 @@ val sparkVersion = "3.5.0"
 val sparkMajorVersion = sparkVersion.substring(0, sparkVersion.lastIndexOf("."))
 
 organization := "com.amazon.ion"
+organizationHomepage := Some(url("https://amazon-ion.github.io/ion-docs/"))
 name := s"ion-spark-data-source-$sparkMajorVersion"
+homepage := Some(url("https://github.com/amazon-ion/ion-spark-data-source"))
+developers := List(
+  Developer(
+    "ion-team",
+    "Amazon Ion Team",
+    "ion-team@amazon.com",
+    url("https://github.com/amazon-ion")
+  )
+)
+
 // force the artifact name in maven to keep the . in Spark version rather than substitute it with a -
 moduleName := name.value
 versionScheme := Some("semver-spec")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.11.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")


### PR DESCRIPTION
### Issue #, if available: n/a

### Description of changes:
This PR adds a release workflow for publishing new releases of ion-spark-data-source.

The bulk of the release logic is handled by a sbt plugin called `sbt-ci-release`, which handles generating checksums, digital signatures, and uploading via the maven protocol.

As part of this, sbt was updated to version `1.11.4` in order to fix an incompatibility between `sbt-ci-release` and 1.10.0.

There are a few variables that sbt-ci-release needs in order to automate the build and publish to maven. Some of the values do not line up exactly with what we have stored, so there is a step within the workflow to transform the data we do have, into what the plugin requires.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
