### PR TITLE
Upgrade Spark to 4.1.1 for emr-spark-8.1.0 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-val sparkVersion = "4.0.1"
+val sparkVersion = "4.1.1"
 val sparkMajorVersion = sparkVersion.substring(0, sparkVersion.lastIndexOf("."))
 
 organization := "com.amazon.ion"


### PR DESCRIPTION
## Summary
Bumps Spark version from 4.0.1 to 4.1.1 to support the emr-spark-8.1.0 release.

## Verification
- **Compilation**: Clean, zero errors on Spark 4.1.1
- **Tests**: 720 passed, 0 failed (JDK 17, Scala 2.13)
- **API compatibility**: No breaking changes between Spark 4.0.1 and 4.1.1 for this codebase

## Context
emr-spark-8.1.0 (Spark 4.1.1) is targeting GA by end of Q2. The ion-spark-data-source RPM build is currently failing in the nightly pipeline because the existing artifact targets Spark 4.0.

## Change
```diff
- val sparkVersion = "4.0.1"
+ val sparkVersion = "4.1.1"
```