### PR TITLE
Bump Spark version from 4.0.1 to 4.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-val sparkVersion = "4.0.1"
+val sparkVersion = "4.1.1"
 val sparkMajorVersion = sparkVersion.substring(0, sparkVersion.lastIndexOf("."))
 
 organization := "com.amazon.ion"


### PR DESCRIPTION
## Changes
Update `sparkVersion` to 4.1.1 to publish `ion-spark-data-source-4.1_2.13` artifact for EMR Spark 4.1.x support.

## Testing
All 720 tests pass on JDK 17.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
